### PR TITLE
Add PDF text extraction service with PdfPig

### DIFF
--- a/src/Application/Interfaces/IPdfTextExtractionService.cs
+++ b/src/Application/Interfaces/IPdfTextExtractionService.cs
@@ -1,0 +1,14 @@
+using Application.Models;
+
+namespace Application.Interfaces;
+
+public interface IPdfTextExtractionService
+{
+    /// <summary>
+    /// Extracts text from a PDF stream, returning full text and per-page text.
+    /// </summary>
+    /// <param name="pdfStream">The PDF file stream to read from.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>PDF text content with full text and page-by-page breakdown.</returns>
+    Task<PdfTextContent> ExtractTextAsync(Stream pdfStream, CancellationToken cancellationToken = default);
+}

--- a/src/Application/Models/PdfTextContent.cs
+++ b/src/Application/Models/PdfTextContent.cs
@@ -1,0 +1,13 @@
+namespace Application.Models;
+
+public class PdfTextContent
+{
+    public string FullText { get; set; } = string.Empty;
+    public IReadOnlyList<PageText> Pages { get; set; } = Array.Empty<PageText>();
+}
+
+public class PageText
+{
+    public int PageNumber { get; set; }
+    public string Text { get; set; } = string.Empty;
+}

--- a/src/Infrastructure/DependencyInjection.cs
+++ b/src/Infrastructure/DependencyInjection.cs
@@ -1,6 +1,7 @@
 using Application.Interfaces;
 using Infrastructure.Persistence;
 using Infrastructure.Repositories;
+using Infrastructure.Services;
 using Infrastructure.Storage;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -62,6 +63,9 @@ public static class DependencyInjection
             var logger = sp.GetRequiredService<ILogger<LocalFileStorageService>>();
             return new LocalFileStorageService(storageRoot, logger);
         });
+
+        // Register PDF text extraction service
+        services.AddScoped<IPdfTextExtractionService, PdfPigTextExtractionService>();
 
         return services;
     }

--- a/src/Infrastructure/Infrastructure.csproj
+++ b/src/Infrastructure/Infrastructure.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
     <PackageReference Include="Tesseract" Version="5.2.0" />
+    <PackageReference Include="UglyToad.PdfPig" Version="1.7.0-custom-5" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Infrastructure/Services/PdfPigTextExtractionService.cs
+++ b/src/Infrastructure/Services/PdfPigTextExtractionService.cs
@@ -1,0 +1,103 @@
+using Application.Interfaces;
+using Application.Models;
+using Microsoft.Extensions.Logging;
+using System.Text;
+using UglyToad.PdfPig;
+using UglyToad.PdfPig.Content;
+
+namespace Infrastructure.Services;
+
+public class PdfPigTextExtractionService : IPdfTextExtractionService
+{
+    private readonly ILogger<PdfPigTextExtractionService> _logger;
+
+    public PdfPigTextExtractionService(ILogger<PdfPigTextExtractionService> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<PdfTextContent> ExtractTextAsync(Stream pdfStream, CancellationToken cancellationToken = default)
+    {
+        if (pdfStream == null || !pdfStream.CanRead)
+        {
+            _logger.LogWarning("Invalid PDF stream provided");
+            return new PdfTextContent();
+        }
+
+        try
+        {
+            return await Task.Run(() => ExtractTextInternal(pdfStream), cancellationToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Error extracting text from PDF");
+            return new PdfTextContent();
+        }
+    }
+
+    private PdfTextContent ExtractTextInternal(Stream pdfStream)
+    {
+        try
+        {
+            using var document = PdfDocument.Open(pdfStream);
+
+            var pages = new List<PageText>();
+            var fullTextBuilder = new StringBuilder();
+
+            foreach (var page in document.GetPages())
+            {
+                var pageText = ExtractPageText(page);
+
+                pages.Add(new PageText
+                {
+                    PageNumber = page.Number,
+                    Text = pageText
+                });
+
+                fullTextBuilder.AppendLine(pageText);
+            }
+
+            return new PdfTextContent
+            {
+                FullText = NormalizeText(fullTextBuilder.ToString()),
+                Pages = pages
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to open or read PDF document");
+            return new PdfTextContent();
+        }
+    }
+
+    private string ExtractPageText(Page page)
+    {
+        try
+        {
+            var text = page.Text;
+            return NormalizeText(text);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to extract text from page {PageNumber}", page.Number);
+            return string.Empty;
+        }
+    }
+
+    private string NormalizeText(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return string.Empty;
+
+        // Normalize line breaks
+        text = text.Replace("\r\n", "\n").Replace("\r", "\n");
+
+        // Replace multiple spaces with single space
+        text = System.Text.RegularExpressions.Regex.Replace(text, @" +", " ");
+
+        // Replace multiple newlines with double newline (paragraph breaks)
+        text = System.Text.RegularExpressions.Regex.Replace(text, @"\n{3,}", "\n\n");
+
+        return text.Trim();
+    }
+}


### PR DESCRIPTION
This PR adds a minimal PDF text extraction service using PdfPig for reading contract documents. Features: IPdfTextExtractionService interface, PdfTextContent models with full text and per-page breakdown, PdfPigTextExtractionService implementation using UglyToad.PdfPig, whitespace and line break normalization, graceful handling of malformed/encrypted PDFs, comprehensive error logging, background task execution. Added UglyToad.PdfPig package. Registered service in DI as scoped. No OCR, no DOCX support - minimal and focused on text-based PDFs only. Returns empty results on errors rather than throwing exceptions. Clean, idiomatic .NET 9 implementation.