### PR TITLE
chore(docs): add Copilot instructions, prompts, and usage guide

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,18 @@
+# Copilot Instructions (Repo-wide)
+
+These instructions provide always-on context for GitHub Copilot and other AI assistants operating within this repository.
+
+## Purpose
+This file defines the default behavior and expectations for AI-generated suggestions, PR descriptions, and other assisted workflows.
+
+## Always‑On Context
+- **Be concise and factual.** Provide clear, actionable guidance and avoid unnecessary verbosity.
+- **Follow repository conventions.** Respect the existing architecture (Clean Architecture with `Domain`, `Application`, `Infrastructure`, `WebApi`) and folder layout.
+- **Respect naming and style.** Use the same naming patterns, idioms, and coding styles already present in the project.
+- **Avoid breaking changes.** Prefer safe, incremental changes; only introduce breaking changes when explicitly requested.
+- **Focus on correctness & maintainability.** Prioritize readable, testable code and follow the existing patterns for dependency injection, layering, and error handling.
+- **Ask clarifying questions when uncertain.** If a request is ambiguous or missing critical information, ask for clarification rather than guessing.
+
+## Scope
+- Applies to AI interactions across the entire repository (backend, frontend, docs, scripts).
+- Path-specific instructions should be placed under `.github/instructions/` if needed.

--- a/.github/copilot.yml
+++ b/.github/copilot.yml
@@ -1,0 +1,17 @@
+# GitHub Copilot configuration for this repository.
+# See: https://docs.github.com/en/copilot/reference/customization-cheat-sheet
+
+suggestions:
+  # Enable inline suggestions by default
+  enabled: true
+  inline: true
+  # Enable Copilot Chat in supported editors
+  chat: true
+
+# Exclude certain paths from Copilot suggestions to reduce noise.
+# For example, generated files, docs, or third-party code.
+files:
+  exclude:
+    - "docs/**"
+    - "scripts/**"
+    - "webapp/node_modules/**"

--- a/.github/instructions/backend.instructions.md
+++ b/.github/instructions/backend.instructions.md
@@ -1,0 +1,10 @@
+# Backend Instructions (Path-specific)
+
+This file provides path-specific guidance for AI assistants working on backend code under `src/`.
+
+## Backend Guidance
+- **Follow clean architecture layers**: Keep business logic in `Application`, domain rules in `Domain`, data access in `Infrastructure`, and API contracts in `WebApi`.
+- **Use DI & interfaces**: Prefer injecting services via interfaces from `Application/Interfaces` and register implementations in `Infrastructure/DependencyInjection.cs` or `WebApi/Program.cs`.
+- **Keep controllers thin**: Controllers should delegate to services and return simple DTOs.
+- **Prefer `async/await`**: Avoid `.Result`/`.Wait()` and always accept `CancellationToken` in public async methods.
+- **Tests**: Add unit tests under `tests/ContractIntel.Tests` for new business logic; use xUnit and `NullLogger` when needed.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,10 @@
+# Docs Instructions (Path-specific)
+
+This file provides guidance for AI assistants working on documentation under `docs/`.
+
+## Docs Guidance
+- **Clarity first**: Write docs that are easy to scan; use headings, lists, and short paragraphs.
+- **Consistency**: Follow the style and structure of existing docs (use markdown headings, code blocks, and unambiguous language).
+- **Keep updated**: When code changes, update any related docs (README, setup steps, architecture notes).
+- **Examples**: Prefer concrete examples (commands, config snippets) over abstract descriptions.
+- **Cross-linking**: Link to other docs or source files where it helps navigation.

--- a/.github/instructions/frontend.instructions.md
+++ b/.github/instructions/frontend.instructions.md
@@ -1,0 +1,11 @@
+# Frontend Instructions (Path-specific)
+
+This file provides guidance for AI assistants working on frontend code under `webapp/`.
+
+## Frontend Guidance
+- **Use React best practices**: Prefer functional components with hooks, avoid unnecessary rerenders, and keep components focused.
+- **State management**: Use React Query for server state; use local component state only when appropriate.
+- **API access**: Use the centralized `webapp/src/lib/api.ts` client rather than calling `fetch` directly.
+- **Type safety**: Prefer explicit TypeScript types; avoid `any` and keep type definitions close to usage.
+- **Styling**: Keep styles scoped (CSS modules / component-level) and avoid global style side effects.
+- **Testing**: Add/extend React Testing Library tests under `webapp/src/__tests__` where appropriate; keep tests fast and deterministic.

--- a/.github/instructions/scripts.instructions.md
+++ b/.github/instructions/scripts.instructions.md
@@ -1,0 +1,9 @@
+# Scripts Instructions (Path-specific)
+
+This file provides guidance for AI assistants working on project scripts (e.g., `scripts/`).
+
+## Scripts Guidance
+- **Keep scripts simple**: Scripts should solve a narrow task (e.g., generating PR descriptions, running checks).
+- **Cross-platform**: Prefer Node.js (JS/TS) scripts or cross-platform shell commands to support Windows/macOS/Linux.
+- **Documentation**: Update README or script help output when adding new scripts.
+- **Avoid secrets**: Do not store credentials or secrets in scripts; use environment variables when needed.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,10 @@
+# Tests Instructions (Path-specific)
+
+This file provides guidance for AI assistants working on automated tests in `tests/`.
+
+## Tests Guidance
+- **Unit tests first**: Prefer unit tests that validate business logic in `src/Application` and `src/Domain` layers.
+- **Use xUnit**: The backend tests use xUnit; follow existing patterns in `tests/ContractIntel.Tests`.
+- **Arrange/Act/Assert**: Keep tests structured and readable. Use small helper methods where it improves clarity.
+- **Mocks & fakes**: Use lightweight fakes/mocks (e.g., `NullLogger`) rather than full DI containers unless needed.
+- **Fast & deterministic**: Avoid integration-style tests that depend on external services or timing.

--- a/.github/prompts/ai-dev-step.prompt.md
+++ b/.github/prompts/ai-dev-step.prompt.md
@@ -1,0 +1,42 @@
+# AI Assistant Prompt Template (Step-based)
+
+This file is a reusable prompt template for generating or iterating on development tasks. It is designed to be filled in with the variables below and used as the system/user prompt for an AI assistant.
+
+---
+
+## Variables
+
+- `{{projectName}}` — The name of the project (e.g., "Contract Intelligence").
+- `{{branchName}}` — (Optional) The git branch name to work on (e.g., `feat/core-data-model`).
+- `{{taskTitle}}` — A short title for the task (e.g., "Core Data Model & Persistence").
+- `{{taskDescription}}` — A brief description of what needs to be implemented.
+- `{{goals}}` — A bullet list of clear goals or acceptance criteria.
+- `{{constraints}}` — Any important constraints, preferences, or additional guidance.
+- `{{notes}}` — Any extra context or clarifications that may help.
+
+---
+
+## Prompt Template
+
+You are an expert software engineer and AI assistant helping to implement a feature for **{{projectName}}**.
+
+{{#if branchName}}
+**Branch:** `{{branchName}}`
+{{/if}}
+
+### Task
+{{taskTitle}}
+
+{{taskDescription}}
+
+### Goals
+{{goals}}
+
+### Constraints / Notes
+{{constraints}}
+
+{{notes}}
+
+---
+
+> **Usage:** Replace the `{{...}}` placeholders with actual values. Keep prompts concise, focused, and aligned with the project’s clean architecture and code quality standards.

--- a/.github/prompts/bug-fix.prompt.md
+++ b/.github/prompts/bug-fix.prompt.md
@@ -1,0 +1,35 @@
+# Bug Fix Prompt Template
+
+Use this prompt when asking the assistant to identify, diagnose, and fix a bug in the codebase.
+
+## Variables
+
+- `{{symptom}}` — A short description of the observed problem (e.g., "API returns 500 when retrieving contracts").
+- `{{reproductionSteps}}` — Steps to reproduce the issue.
+- `{{filePaths}}` — The relevant file(s) or module(s) to inspect.
+- `{{constraints}}` — Any constraints (e.g., must preserve API contracts, no breaking changes).
+- `{{notes}}` — Additional context (e.g., recent refactors, related issues).
+
+---
+
+### Bug Fix Task
+
+We are experiencing the following issue:
+
+**Symptom:** {{symptom}}
+
+**Reproduction Steps:**
+{{reproductionSteps}}
+
+**Relevant Files/Areas:**
+{{filePaths}}
+
+### Goals
+- Identify the root cause of the issue.
+- Provide a minimal and correct fix.
+- Add or update tests to prevent regressions.
+
+### Constraints / Notes
+{{constraints}}
+
+{{notes}}

--- a/.github/prompts/docs-update.prompt.md
+++ b/.github/prompts/docs-update.prompt.md
@@ -1,0 +1,32 @@
+# Documentation Update Prompt Template
+
+Use this prompt when asking the assistant to update or create documentation (README, guides, architecture docs, etc.).
+
+## Variables
+
+- `{{docTarget}}` — The document or section to update (e.g., "README installation section", "architecture overview").
+- `{{changes}}` — What needs to be added or changed.
+- `{{audience}}` — Who the docs are for (e.g., "new contributors", "API consumers").
+- `{{constraints}}` — Any constraints (e.g., keep language simple, keep short).
+- `{{notes}}` — Additional context.
+
+---
+
+### Documentation Task
+
+Update or create documentation for:
+
+**Target:** {{docTarget}}
+
+**Changes:**
+{{changes}}
+
+### Goals
+- Make the documentation clear, accurate, and easy to follow.
+- Ensure it aligns with existing style and structure.
+- Include examples or commands when relevant.
+
+### Constraints / Notes
+{{constraints}}
+
+{{notes}}

--- a/.github/prompts/refactor.prompt.md
+++ b/.github/prompts/refactor.prompt.md
@@ -1,0 +1,30 @@
+# Refactor Prompt Template
+
+Use this prompt when asking the assistant to refactor existing code for readability, maintainability, or testability without changing behavior.
+
+## Variables
+
+- `{{targetArea}}` — The area of code to refactor (e.g., "contract extraction pipeline", "API controllers").
+- `{{reason}}` — Why this refactor is needed (e.g., "reduce duplication", "improve testability").
+- `{{constraints}}` — Constraints (e.g., "no behavior changes", "keep public API stable").
+- `{{notes}}` — Additional context or requirements.
+
+---
+
+### Refactor Task
+
+Refactor the following area of the codebase:
+
+**Target Area:** {{targetArea}}
+
+**Reason:** {{reason}}
+
+### Goals
+- Improve code readability and maintainability.
+- Keep behavior unchanged.
+- Add or improve unit tests where appropriate.
+
+### Constraints / Notes
+{{constraints}}
+
+{{notes}}

--- a/.github/prompts/test-generation.prompt.md
+++ b/.github/prompts/test-generation.prompt.md
@@ -1,0 +1,31 @@
+# Test Generation Prompt Template
+
+Use this prompt when asking the assistant to add or improve automated tests for a specific piece of functionality.
+
+## Variables
+
+- `{{subject}}` — The class, method, or feature under test.
+- `{{testScope}}` — What should be tested (e.g., edge cases, error handling, happy path).
+- `{{framework}}` — Test framework / style (e.g., xUnit, React Testing Library).
+- `{{constraints}}` — Any special constraints (e.g., keep test runtime fast, avoid flakiness).
+- `{{notes}}` — Additional context.
+
+---
+
+### Test Generation Task
+
+Generate or improve tests for:
+
+**Subject:** {{subject}}
+
+**Scope:** {{testScope}}
+
+### Goals
+- Ensure behavior is correctly asserted.
+- Cover key edge cases and error conditions.
+- Keep tests fast, deterministic, and easy to understand.
+
+### Constraints / Notes
+{{constraints}}
+
+{{notes}}

--- a/docs/COPILOT_USAGE_GUIDE.md
+++ b/docs/COPILOT_USAGE_GUIDE.md
@@ -1,0 +1,59 @@
+# Copilot Usage Guide
+
+This guide explains how to use GitHub Copilot and Copilot Chat effectively in the Contract Intel repository.
+
+## 1) Where to find guidance
+
+### Repo-wide instructions
+- **File:** `.github/copilot-instructions.md`
+- **Purpose:** Always‑on behavior rules and high-level expectations for AI-generated code and prompts.
+
+### Path-specific instructions
+- **Folder:** `.github/instructions/`
+- **Purpose:** Tailored guidance for different parts of the project (backend, frontend, docs, tests, scripts).
+- **Examples:**
+  - `backend.instructions.md` — backend architecture, DI, controller patterns
+  - `frontend.instructions.md` — React/TypeScript patterns, API client usage
+  - `docs.instructions.md` — doc style and structure
+  - `tests.instructions.md` — testing style and conventions
+  - `scripts.instructions.md` — scripting best practices
+
+## 2) Using prompt templates
+
+### Where they live
+- **Folder:** `.github/prompts/`
+- **Purpose:** Provide consistent structured prompts for common tasks.
+
+### Common templates
+- `ai-dev-step.prompt.md` — general feature/task prompt
+- `bug-fix.prompt.md` — diagnosing/fixing bugs
+- `refactor.prompt.md` — refactoring without changing behavior
+- `test-generation.prompt.md` — creating or improving tests
+- `docs-update.prompt.md` — updating or adding documentation
+
+### How to use
+1. Open the relevant `.prompt.md` file.
+2. Replace the `{{...}}` placeholders with real values.
+3. Copy the filled prompt into Copilot Chat or your assistant interface.
+
+## 3) Copilot configuration
+
+### File
+- `.github/copilot.yml`
+
+### What it controls
+- Enables inline suggestions and Copilot Chat.
+- Excludes certain paths (docs, scripts, node_modules) from suggestions to reduce noise.
+
+## 4) Best practices when using Copilot
+
+- **Validate changes**: Always review AI-generated code the same way you would any PR.
+- **Keep changes small**: Use Copilot for focused tasks (e.g., a single bug fix, one refactor) rather than broad rewrites.
+- **Ask clarifying questions**: If the assistant output is unclear, provide more context and iteratively refine the prompt.
+- **Document AI-aided work**: When a PR includes generated code, note it in the PR description (e.g., "Generated with Copilot using `<prompt>`").
+
+## 5) When not to rely on Copilot
+
+- Complex architectural decisions that require deep domain knowledge
+- Security-sensitive code (e.g., authentication, encryption) without thorough review
+- Anything where correctness is critical and must be verified by an expert


### PR DESCRIPTION
Adds repo-wide Copilot instructions, path-specific guidance, reusable prompt templates, and a usage guide.